### PR TITLE
Adding functionality to provide channel config from imagej plugin

### DIFF
--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
@@ -249,7 +249,8 @@ public class ImpartialController {
         monaiClient.deleteTrain();
 
         JSONObject params = contentPane.getTrainParams();
-        monaiClient.postTrain("impartial", params);
+        String model = "impartial_" + params.getInt("num_channels");
+        monaiClient.postTrain(model, params); 
 
         TrainProgress.monitorTraining(this);
     }
@@ -273,7 +274,8 @@ public class ImpartialController {
                 JSONObject params = new JSONObject();
                 params.put("threshold", (Float) contentPane.getThreshold());
 
-                JSONObject modelOutput = monaiClient.postInferJson("impartial", imageId, params);
+                String model = "impartial_" +  contentPane.getTrainParams().getInt("num_channels");
+                JSONObject modelOutput = monaiClient.postInferJson(model, imageId, params); 
 
                 modelOutput.put("epoch", currentEpoch);
 

--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/TrainPanel.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/TrainPanel.java
@@ -7,6 +7,7 @@ import javax.swing.*;
 public class TrainPanel extends JPanel {
     private ImpartialController controller;
     private final JPanel epochsPanel;
+    private final JPanel nchannelsPanel;
     private final JPanel patchesPanel;
     private final JPanel patiencePanel;
 
@@ -24,6 +25,9 @@ public class TrainPanel extends JPanel {
         JPanel configPanel = new JPanel();
         configPanel.setLayout(new BoxLayout(configPanel, BoxLayout.PAGE_AXIS));
 
+        nchannelsPanel = createParamPanel("nchannels", 1);
+        nchannelsPanel.setToolTipText("number of channels for dataset");
+
         epochsPanel = createParamPanel("epochs", 10);
         epochsPanel.setToolTipText("max number of epochs to train");
 
@@ -33,6 +37,7 @@ public class TrainPanel extends JPanel {
         patiencePanel = createParamPanel("patience", 10);
         patiencePanel.setToolTipText("number of times the evaluation loss can no-decrease before the training stops");
 
+        configPanel.add(nchannelsPanel);
         configPanel.add(epochsPanel);
         configPanel.add(patchesPanel);
         configPanel.add(patiencePanel);
@@ -61,10 +66,12 @@ public class TrainPanel extends JPanel {
     public JSONObject getTrainParams() {
         JSONObject params = new JSONObject();
 
+        JTextField nchannels = (JTextField) nchannelsPanel.getAccessibleContext().getAccessibleChild(1);
         JTextField epochs = (JTextField) epochsPanel.getAccessibleContext().getAccessibleChild(1);
         JTextField patches = (JTextField) patchesPanel.getAccessibleContext().getAccessibleChild(1);
         JTextField patience = (JTextField) patiencePanel.getAccessibleContext().getAccessibleChild(1);
 
+        params.put("num_channels", Integer.parseInt(nchannels.getText()));
         params.put("max_epochs", Integer.parseInt(epochs.getText()));
         params.put("npatches_epoch", Integer.parseInt(patches.getText()));
         params.put("early_stop_patience", Integer.parseInt(patience.getText()));

--- a/impartial/api/lib/configs/impartial.py
+++ b/impartial/api/lib/configs/impartial.py
@@ -30,9 +30,12 @@ class Impartial(TaskConfig):
         ]
 
         # ImPartial config
-        # self.iconfig = DAPI1CH()
-        # self.iconfig = Vectra2Ch1task()
-        self.iconfig = Config_CH2()
+        nChannels = name.split('_')[1]
+        # nChannels = conf.get("nChannels", "1")
+        if nChannels == "1":
+            self.iconfig = Config_CH1()
+        if nChannels == "2":
+            self.iconfig = Config_CH2()
 
         # Network
         self.network = UNet(

--- a/impartial/api/main.py
+++ b/impartial/api/main.py
@@ -25,10 +25,10 @@ class Impartial(MONAILabelApp):
         for c in get_class_names(lib.configs, "TaskConfig"):
             name = c.split(".")[-2].lower()
             configs[name] = c
-
+        
         configs = {k: v for k, v in sorted(configs.items())}
 
-        models = conf.get("models", "all")
+        models = conf.get("models", "impartial_1,impartial_2")
         if not models:
             print("")
             print("---------------------------------------------------------------------------------------")
@@ -42,24 +42,15 @@ class Impartial(MONAILabelApp):
         models = models.split(",")
         models = [m.strip() for m in models]
         
-        invalid = [m for m in models if m != "all" and not configs.get(m)]
-        if invalid:
-            print("")
-            print("---------------------------------------------------------------------------------------")
-            print(f"Invalid Model(s) are provided: {invalid}")
-            print("Following are the available models.  You can pass comma (,) seperated names to pass multiple")
-            print(f"    all, {', '.join(configs.keys())}")
-            print("---------------------------------------------------------------------------------------")
-            print("")
-            exit(-1)
-
         self.models: Dict[str, TaskConfig] = {}
-        for n in models:
-            for k, v in configs.items():
-                if self.models.get(k):
-                    continue
-                if n == k or n == "all":
-                    logger.info(f"+++ Adding Model: {k} => {v}")
+        for k in models:
+            if self.models.get(k):
+                continue
+            else:
+                model_type = k.split('_')[0]
+                if model_type in configs:
+                    v = configs[model_type]
+                    logger.info(f"+++ Adding Model: {model_type} type: {k} => {v}")
                     self.models[k] = eval(f"{v}()")
                     self.models[k].init(k, self.model_dir, conf, None)
 
@@ -129,13 +120,13 @@ def main():
 
     app_dir = os.path.dirname(__file__)
     studies = os.path.join(app_dir, "..", "..", "Data", "Vectra_WC_2CH_tiff")
-    conf = {}
+    conf = {"models": "impartial_1,impartial_2"}
     app = Impartial(app_dir, studies, conf)
 
     # Train
     app.train(
         request={
-            "model": "impartial",
+            "model": "impartial_2",
             "max_epochs": 100,
             # "dataset": "CacheDataset",
         },


### PR DESCRIPTION
Added support for :
- Impartial to be able to run without changing the dataset config from backend for multichannel images
- Currently supports images with one and two channels
- Added parameter "nchannels" to be provided by user in imagej-plugin based on the input dataset at the time of training