### PR TITLE
Username as user identifier

### DIFF
--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
@@ -154,6 +154,10 @@ public class ImpartialController {
         }
     }
 
+    public String getUserId() {
+        return System.getProperty("user.name").toLowerCase();
+    }
+
     public void onStarted() {
         if (contentPane.getRequestServerCheckBox()) {
             contentPane.setSession(sessionId);
@@ -191,7 +195,7 @@ public class ImpartialController {
             String token = sessionClient.restoreSession(sessionId).getString("token");
             monaiClient.setToken(token);
             sessionClient.setToken(token);
-            sessionId = sessionClient.getSessionDetails().getString("session_id");
+            this.sessionId = sessionClient.getSessionDetails().getString("session_id");
         } catch (IOException e) {
             showIOError(e);
             throw e;
@@ -726,7 +730,7 @@ public class ImpartialController {
 
     public void startSession() throws IOException {
         try {
-            String token = sessionClient.postSession(sessionId).getString("token");
+            String token = sessionClient.postSession(getUserId()).getString("token");
             sessionClient.setToken(token);
             monaiClient.setToken(token);
             sessionId = sessionClient.getSessionDetails().getString("session_id");

--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/ServerPanel.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/ServerPanel.java
@@ -17,6 +17,7 @@ public class ServerPanel extends JPanel {
     private final JTextField monaiUrlTextField;
     private final JPanel sessionPanel;
     private JLabel sessionLabel;
+    private JLabel usernameLabel;
     private JCheckBox requestServerCheckBox;
     private JButton startStopButton;
     private String url = "http://localhost:8000";
@@ -41,6 +42,7 @@ public class ServerPanel extends JPanel {
         sessionPanel = createSessionPanel();
         sessionPanel.setVisible(false);
 
+        add(createUserPanel());
         add(monaiUrlTextField);
         add(createButtonsPanel());
         add(sessionPanel);
@@ -110,6 +112,21 @@ public class ServerPanel extends JPanel {
         scrollPane.setPreferredSize(new Dimension(500, 500));
         JOptionPane.showMessageDialog(null, scrollPane, "ImPartial Terms of Use",
                 JOptionPane.WARNING_MESSAGE);
+    }
+
+    private JPanel createUserPanel() {
+        JPanel userPanel = new JPanel();
+        userPanel.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        userPanel.setAlignmentX(LEFT_ALIGNMENT);
+
+        usernameLabel = new JLabel(
+                String.format("<html> <strong>user</strong> %s</html>",  controller.getUserId())
+        );
+        userPanel.setToolTipText("username of the currently logged-in user on the operating system");
+
+        userPanel.add(usernameLabel);
+
+        return userPanel;
     }
 
     private JPanel createButtonsPanel() {

--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/SessionClient.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/SessionClient.java
@@ -80,10 +80,10 @@ public class SessionClient extends BaseApiClient {
         }
     }
 
-    public JSONObject postSession(String sessionId) throws IOException {
+    public JSONObject postSession(String userId) throws IOException {
         HttpUrl.Builder httpUrlBuilder = getHttpUrlBuilder();
         httpUrlBuilder.addPathSegments("session");
-        httpUrlBuilder.addQueryParameter("session_id", sessionId);
+        httpUrlBuilder.addQueryParameter("user_id", userId);
 
         HttpUrl url = httpUrlBuilder.build();
 

--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/TrainPanel.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/TrainPanel.java
@@ -51,7 +51,7 @@ public class TrainPanel extends JPanel {
             }
         });
 
-        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
         buttonPanel.setAlignmentX(LEFT_ALIGNMENT);
         buttonPanel.add(startStopButton);
 
@@ -60,9 +60,8 @@ public class TrainPanel extends JPanel {
     }
 
     private JPanel createParamPanel(String name, int value) {
-        JPanel paramPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        JPanel paramPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
         paramPanel.setAlignmentX(LEFT_ALIGNMENT);
-        paramPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
 
         paramPanel.add(new JLabel(String.format("<html> <strong>%s</strong> &nbsp;", name)));
         paramPanel.add(new JTextField(String.valueOf(value), 3));


### PR DESCRIPTION
As of today, the user remote IP address is used as a unique identifier. This can be problematic when trying to identify which user worked on which session as more than one user can work from the same station. To tackle this problem and given that ImageJ runs as a desktop app it's possible to get the username with the Java command
System.getProperty("user.name")
which return the username of the user that is currently logged in to the OS.
This doesn't add any additional authentication requirements or complexity but under the assumption that users log in to their work station using their credentials then it makes it possible to identity them uniquely even if they share the same computer.
