### PR TITLE
Upload model checkpoint

### DIFF
--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/BackgroundTaskRunner.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/BackgroundTaskRunner.java
@@ -1,0 +1,72 @@
+package org.nadeemlab.impartial;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+
+public class BackgroundTaskRunner<Void> extends SwingWorker<Void, Void> {
+    private final Callable<Void> task;
+    private final Runnable onSuccess;
+    private final Runnable onCancel;
+    private final Consumer<Exception> onException;
+    private final JDialog dialog;
+
+    public BackgroundTaskRunner(Frame parent, String dialogMessage, Callable<Void> task, Runnable onSuccess,
+                                Runnable onCancel, Consumer<Exception> onException) {
+        this.task = task;
+        this.onSuccess = onSuccess;
+        this.onCancel = onCancel;
+        this.onException = onException;
+
+        dialog = createDialog(parent, dialogMessage);
+    }
+
+    public BackgroundTaskRunner(Frame parent, String dialogMessage, Callable<Void> task, Consumer<Exception> onException) {
+        this(parent, dialogMessage, task, () -> {}, () -> {}, onException);
+    }
+
+    private JDialog createDialog(Frame parent, String dialogMessage) {
+        JOptionPane optionPane = new JOptionPane(
+                dialogMessage,
+                JOptionPane.INFORMATION_MESSAGE,
+                JOptionPane.DEFAULT_OPTION,
+                null, new Object[]{}, null
+        );
+        optionPane.setOptions(null);
+
+        JDialog dialog = new JDialog(parent, "Background task", false);
+        dialog.setContentPane(optionPane);
+        dialog.getRootPane().getDefaultButton().setVisible(false);
+        dialog.setResizable(false);
+        dialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
+        dialog.setModal(false);
+        dialog.setLocationRelativeTo(parent);
+        dialog.pack();
+
+        return dialog;
+    }
+
+    @Override
+    protected Void doInBackground() throws Exception {
+        dialog.setVisible(true);
+        return task.call();
+    }
+
+    @Override
+    protected void done() {
+        Toolkit.getDefaultToolkit().beep();
+        dialog.dispose();
+        if (isCancelled()) {
+            onCancel.run();
+        } else {
+            try {
+                get();
+                onSuccess.run();
+            } catch (InterruptedException | ExecutionException e) {
+                onException.accept(e);
+            }
+        }
+    }
+}

--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
@@ -44,8 +44,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Timer;
 import java.util.*;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -775,11 +777,20 @@ public class ImpartialController {
         String model = "impartial_" + numberOfChannels;
         int res = fileChooser.showOpenDialog(mainFrame);
         if (res == JFileChooser.APPROVE_OPTION) {
-            try {
+            Callable<Void> task = () -> {
                 monaiClient.putModel(model, fileChooser.getSelectedFile());
-            } catch (IOException e) {
-                showIOError(e);
-            }
+                return null;
+            };
+            Consumer<Exception> onError = e -> JOptionPane.showMessageDialog(contentPane,
+                    "Error uploading model checkpoint: " + e.getMessage(),
+                    "Upload error",
+                    JOptionPane.ERROR_MESSAGE
+            );
+
+            BackgroundTaskRunner<Void> taskRunner = new BackgroundTaskRunner<>(
+                    this.mainFrame, "Uploading model", task, onError
+            );
+            taskRunner.execute();
         }
     }
 

--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
@@ -762,6 +762,18 @@ public class ImpartialController {
         }
     }
 
+    public void uploadModelCheckpoint() {
+        String model = "impartial_" + numberOfChannels;
+        int res = fileChooser.showOpenDialog(mainFrame);
+        if (res == JFileChooser.APPROVE_OPTION) {
+            try {
+                monaiClient.putModel(model, fileChooser.getSelectedFile());
+            } catch (IOException e) {
+                showIOError(e);
+            }
+        }
+    }
+
     public JSONObject getSessions() {
         try {
             return sessionClient.getSessions();

--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/ImpartialController.java
@@ -763,6 +763,15 @@ public class ImpartialController {
     }
 
     public void uploadModelCheckpoint() {
+        if (numberOfChannels == 0) {
+            JOptionPane.showMessageDialog(contentPane,
+                    "Please upload an image first.",
+                    "Upload error",
+                    JOptionPane.ERROR_MESSAGE
+            );
+            return;
+        }
+
         String model = "impartial_" + numberOfChannels;
         int res = fileChooser.showOpenDialog(mainFrame);
         if (res == JFileChooser.APPROVE_OPTION) {

--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/InferPanel.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/InferPanel.java
@@ -9,6 +9,7 @@ public class InferPanel extends JPanel {
     private final JLabel thresholdValue;
     private JButton inferButton;
     private JButton downloadButton;
+    private JButton uploadButton;
     private final JSlider thresholdSlider = new JSlider(JSlider.HORIZONTAL, 0, 100, 50);
 
     InferPanel(ImpartialController controller) {
@@ -35,8 +36,9 @@ public class InferPanel extends JPanel {
         panel.add(thresholdValue);
         panel.add(createThresholdSlider());
 
+        add(createModelPanel());
         add(panel);
-        add(createModelButtons());
+        add(createInferButtonPanel());
     }
 
     private JPanel createThresholdSlider() {
@@ -73,20 +75,40 @@ public class InferPanel extends JPanel {
         return sliderPanel;
     }
 
-    private JPanel createModelButtons() {
-        JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+    private JPanel createModelPanel() {
+//        JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        panel.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+        JLabel modelLabel = new JLabel("model");
+        modelLabel.setFont(modelLabel.getFont().deriveFont(Font.BOLD));
+
+        downloadButton = new JButton("download");
+        downloadButton.addActionListener(e -> controller.downloadModelCheckpoint());
+        downloadButton.setEnabled(false);
+
+        uploadButton = new JButton("upload");
+        uploadButton.addActionListener(e -> controller.uploadModelCheckpoint());
+        uploadButton.setEnabled(false);
+
+        panel.add(modelLabel);
+        panel.add(Box.createHorizontalGlue());
+        panel.add(uploadButton);
+        panel.add(downloadButton);
+
+        return panel;
+    }
+
+    private JPanel createInferButtonPanel() {
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
         panel.setAlignmentX(Component.LEFT_ALIGNMENT);
 
         inferButton = new JButton("infer");
         inferButton.addActionListener(e -> controller.infer());
         inferButton.setEnabled(false);
 
-        downloadButton = new JButton("download");
-        downloadButton.addActionListener(e -> controller.downloadModelCheckpoint());
-        downloadButton.setEnabled(false);
-
         panel.add(inferButton);
-        panel.add(downloadButton);
 
         return panel;
     }
@@ -106,12 +128,14 @@ public class InferPanel extends JPanel {
     public void onStarted() {
         thresholdSlider.setEnabled(true);
         inferButton.setEnabled(true);
+        uploadButton.setEnabled(true);
         downloadButton.setEnabled(true);
     }
 
     public void onStopped() {
         thresholdSlider.setEnabled(false);
         inferButton.setEnabled(false);
+        uploadButton.setEnabled(false);
         downloadButton.setEnabled(false);
     }
 }

--- a/imagej-plugin/src/main/java/org/nadeemlab/impartial/MonaiLabelClient.java
+++ b/imagej-plugin/src/main/java/org/nadeemlab/impartial/MonaiLabelClient.java
@@ -54,6 +54,28 @@ public class MonaiLabelClient extends BaseApiClient {
         }
     }
 
+    public void putModel(String model, File file) throws IOException {
+        RequestBody requestBody = new MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart("file", file.getName(), RequestBody.create(MediaType.parse("application/octet-stream"), file))
+                .build();
+
+        HttpUrl url = getHttpUrlBuilder()
+                .addPathSegments("model/" + model)
+                .build();
+
+        Request request = getRequestBuilder()
+                .url(url)
+                .addHeader("accept", "application/json")
+                .addHeader("Content-Type", "multipart/form-data")
+                .put(requestBody)
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            raiseForStatus(response);
+        }
+    }
+
     public JSONObject postInferJson(String model, String imageId, JSONObject params) throws IOException {
         RequestBody body = new MultipartBody.Builder()
                 .setType(MultipartBody.FORM)


### PR DESCRIPTION
Add the ability for users to upload pre-trained models from the ImPartial plugin UI in ImageJ.
Assumptions
* There must have uploaded at least one image to the dataset first
* Is responsibility of the user to ensure the number of channels of the model match the number of channels of the dataset
* The pre-trained model can have arbitrary filename, so that users can use meaningful names to store their models
* Introduce the BackgroundTaskRunner to standardize the way long tasks are ran in the background without blocking the UI